### PR TITLE
export query latency metrics to prometheus

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -14,7 +14,7 @@ type App struct {
 	Exitnode string `env:"EXITNODE" envDefault:"local-laptop"`
 
 	// Provider is a name/domain of the current provider.
-	Provider string `env:"PROVIDER" envDefault:"staging.neon.tech"`
+	Provider string `env:"PROVIDER" envDefault:"stage.neon.tech"`
 
 	// NeonAPIKey is an API key for the neon.
 	NeonAPIKey string `env:"NEON_API_KEY,required"`

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ func main() {
 	}
 	log.Info(ctx, "starting main rule", zap.Any("rule", mainRule))
 
+	base.StartPrometheus()
+
 	globalExecutor := rules.NewExecutor(base)
 	rule, err := globalExecutor.ParseJSON(mainRule)
 	if err != nil {


### PR DESCRIPTION
@vadim2404 proposes to show WebSocket latency in the neon prod Grafana dashboard, and I think it would be good to build it over something we already have. Therefore, this PR adds the metrics reporting functionality to the neon light backend, so that we can scrape data and show it in the internal Grafana dashboard. The next step would be adding a Node.js script in this repo to test the latency of WebSocket connections, and the neon-lights app will run the Node.js script then retrieve the latency data in JSON format in stdout.

Thanks for review! By the way, the neon-lights app does not seem responsive now, maybe something went wrong in the backend?

https://github.com/neondatabase/neon/issues/4851